### PR TITLE
File requirements.txt modified

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,2 @@
-Flask==0.10.1
+Flask==2.1.2
 requests


### PR DESCRIPTION
Python app was crashing with following error code:

`ImportError: cannot import name 'Markup' from 'jinja2' (/usr/local/lib/python3.10/dist-packages/jinja2/__init__.py)`

This was caused by an incompatibility between Flask and Jinja2 versions. Changed Flask version in requirements.txt